### PR TITLE
#17: Add 'copy' button for each key and value in the key-values view

### DIFF
--- a/app_view.py
+++ b/app_view.py
@@ -140,5 +140,6 @@ class AppView(tk.Tk):
         self.fill_vault_data_table(node_path)
 
     def _on_copy(self, event):
-        item = self.vault_data.selection()[0]
-        values = self.vault_data.item(item, 'values')
+        item = self.vault_data.selection()
+        if item:
+            values = self.vault_data.item(item[0], 'values')

--- a/app_view_model.py
+++ b/app_view_model.py
@@ -60,6 +60,11 @@ class AppViewModel:
         d3.children = [d31, d33, d34]
         return secret
 
+    def get_node_data(self, node_path):
+        # TODO: only for debug. Should be replaced with implementation of getting data from vault
+        secret = self._get_whole_tree()
+        node = secret.get_node(node_path)
+        return node.kv
 
 class ConnectMethod:
     Token = 'token'


### PR DESCRIPTION
Implemented copying as an event, it will work if we click on the key-value row, so the "copy" icon is not needed as a functionality, but can be added as a functionality description element. Also, changed filling of the table depending on the selected folder.